### PR TITLE
Adding output option for itemized Form 8949 reporting

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,9 +57,13 @@
 2014-12-12 -0.12 -106.36
 2014-01-01 1.01 813.38</code></pre>
 <br/>
+
+<p><i>(note that you probably want to aggregate to transactions to the day, as that corresponds to the reporting requirements for <a href="http://www.irs.gov/pub/irs-pdf/f8949.pdf">Form 8949</a>)</i></p>
+
             <form>
               <strong>Paste your transaction history below</strong>
               <textarea name="capital-gains-and-losses-input" rows="10" cols="30"></textarea><br />
+              <input type="checkbox" name="8949_output" /><label name="8949_output">Output itemized transactions for <a href="http://www.irs.gov/pub/irs-pdf/f8949.pdf">Form 8949</a></label><br />
               <input type="button" onclick="calculateGainsAndLosses()" value="Calculate gains/losses" />
             </form>
             <br/>

--- a/index.html
+++ b/index.html
@@ -58,18 +58,19 @@
 2014-01-01 1.01 813.38</code></pre>
 <br/>
 
-<p><i>(note that you probably want to aggregate to transactions to the day, as that corresponds to the reporting requirements for <a href="http://www.irs.gov/pub/irs-pdf/f8949.pdf">Form 8949</a>)</i></p>
+<p style="font-style: italic">(note that you probably want to aggregate transactions to the day, as that corresponds to the reporting requirements for <a href="http://www.irs.gov/pub/irs-pdf/f8949.pdf">Form 8949</a>)</p>
 
             <form>
               <strong>Paste your transaction history below</strong>
               <textarea name="capital-gains-and-losses-input" rows="10" cols="30"></textarea><br />
-              <input type="checkbox" name="8949_output" /><label name="8949_output">Output itemized transactions for <a href="http://www.irs.gov/pub/irs-pdf/f8949.pdf">Form 8949</a></label><br />
+              <input type="checkbox" id="8949_output" name="8949_output" /><label for="8949_output" name="8949_output">Output itemized transactions for <a href="http://www.irs.gov/pub/irs-pdf/f8949.pdf">Form 8949</a></label><br />
               <input type="button" onclick="calculateGainsAndLosses()" value="Calculate gains/losses" />
             </form>
             <br/>
             <strong>Capital gains and losses result</strong>
             <div id="capital-gains-and-losses-error"></div>
             <div id="capital-gains-and-losses-output"></div>
+            <div id="capital-gains-and-losses-output-8949"></div>
           </section>
         </div>
 


### PR DESCRIPTION
When reporting your bitcoin taxes, you'll probably have to submit an itemized record of each transaction on your Form 8949 (http://www.irs.gov/pub/irs-pdf/f8949.pdf) which accompanies your Schedule D reporting of capital gains. 

While the currency calculator accurately reports your total gains/losses per year, it did not output the results in an itemized format that could be entered in the f8949. 

This pull request adds an option for outputting the itemized transactions for 8949 reporting. 

You can try it out at http://tkriplean.github.io/crypto-currency-calculator/ first if you wish.

p.s. one minor limitation is that the itemized results aren't strongly broken out by year as the summarized gains/losses are. 
